### PR TITLE
Fix wrong regexp for Belgium numbers

### DIFF
--- a/lib/valvat/syntax.rb
+++ b/lib/valvat/syntax.rb
@@ -5,7 +5,7 @@ class Valvat
 
     VAT_PATTERNS = {
         'AT' => /\AATU[0-9]{8}\Z/,                                          # Austria
-        'BE' => /\ABE[0-9]{10}\Z/,                                          # Belgium
+        'BE' => /\ABE0[0-9]{9}\Z/,                                          # Belgium
         'BG' => /\ABG[0-9]{9,10}\Z/,                                        # Bulgaria
         'CY' => /\ACY[0-9]{8}[A-Z]\Z/,                                      # Cyprus
         'CZ' => /\ACZ[0-9]{8,10}\Z/,                                        # Czech Republic

--- a/spec/valvat/syntax_spec.rb
+++ b/spec/valvat/syntax_spec.rb
@@ -24,6 +24,7 @@ describe Valvat::Syntax do
       Valvat::Syntax.validate("BE081733199").should eql(false)
       Valvat::Syntax.validate("BE08173319944").should eql(false)
       Valvat::Syntax.validate("BE081733199H").should eql(false)
+      Valvat::Syntax.validate("BE1817331999").should eql(false)
     end
 
     it "validates a BG vat number" do


### PR DESCRIPTION
According to http://ec.europa.eu/taxation_customs/vies/faq.html#item_11 the correct format for a BE vat number should be **BE0999999999** (note the leading 0).

This request updates the regexp for BE numbers to that format.
