### PR TITLE
fixed exception parsing when extracting returned fault details

### DIFF
--- a/lib/valvat/lookup.rb
+++ b/lib/valvat/lookup.rb
@@ -18,7 +18,7 @@ class Valvat
         response[:valid] && (options[:detail] || options[:requester_vat]) ?
           filter_detail(response) : response[:valid]
       rescue => err
-        if err.respond_to?(:to_hash) && err.to_hash[:fault] && e(rr.to_hash[:fault][:faultstring] || "").upcase =~ /INVALID_INPUT/
+        if err.respond_to?(:to_hash) && err.to_hash[:fault] && (err.to_hash[:fault][:faultstring] || "").upcase =~ /INVALID_INPUT/
           return false
         end
         raise err if options[:raise_error]


### PR DESCRIPTION
Today, the french VAT validation service was done and this unavailability highlighted a tiny spelling mistake int the way fault details is extracted.

``` ruby
1.9.3p125 :003 > Valvat::Lookup.validate('FR 16 434 651 246')
NameError: undefined local variable or method `rr' for Valvat::Lookup:Module
    from /Users/bastien/.rvm/gems/ruby-1.9.3-p125-perf/gems/valvat-0.4.2/lib/valvat/lookup.rb:21:in `rescue in validate'
    from /Users/bastien/.rvm/gems/ruby-1.9.3-p125-perf/gems/valvat-0.4.2/lib/valvat/lookup.rb:16:in `validate'
    from (irb):3
    from /Users/bastien/.rvm/gems/ruby-1.9.3-p125-perf/gems/railties-3.2.6/lib/rails/commands/console.rb:47:in `start'
    from /Users/bastien/.rvm/gems/ruby-1.9.3-p125-perf/gems/railties-3.2.6/lib/rails/commands/console.rb:8:in `start'
    from /Users/bastien/.rvm/gems/ruby-1.9.3-p125-perf/gems/railties-3.2.6/lib/rails/commands.rb:41:in `<top (required)>'
    from script/rails:6:in `require'
    from script/rails:6:in `<main>'
```

![Capture d e cran 2012-12-11 a 12 48 45](https://f.cloud.github.com/assets/1092772/5609/e792461c-4388-11e2-8622-dddfdb3d36fc.png)
![Capture d e cran 2012-12-11 a 12 48 21](https://f.cloud.github.com/assets/1092772/5610/e7a74670-4388-11e2-9fbc-e455cc743a81.png)
