### PR TITLE
Added Checksum::BG

### DIFF
--- a/lib/valvat/checksum/bg.rb
+++ b/lib/valvat/checksum/bg.rb
@@ -6,6 +6,13 @@ class Valvat
       end
       
       def check_digit_natural_person
+        local_person_chk = check_digit_local_natural_person
+
+        return local_person_chk if given_check_digit == local_person_chk
+        check_digit_foreign_natural_person
+      end
+      
+      def check_digit_local_natural_person
         weight = [2, 4, 8, 5, 10, 9, 7, 3, 6]
         chk = figures.map do |fig|
           fig * weight.shift
@@ -15,6 +22,16 @@ class Valvat
         return 0
       end
       
+      def check_digit_foreign_natural_person
+        weight = [21, 19, 17, 13, 11, 9, 7, 3, 1]
+
+        chk = figures.map do |fig|
+          fig * weight.shift
+        end.inject(:+).modulo(10)
+        
+        chk
+      end
+
       def check_digit_legal_person
         prod = 0
         figures.each_with_index do |fig, index|

--- a/spec/valvat/checksum/bg_spec.rb
+++ b/spec/valvat/checksum/bg_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Valvat::Checksum::BG do
-  %w(BG123456786 BG926067143 BG926067770 BG0101011739 BG0121013021 BG0141018959).each do |valid_vat|
+  %w(BG123456786 BG926067143 BG926067770 BG0101011739 BG0121013021 BG5041019992 BG1521687837 BG1431889037).each do |valid_vat|
     it "returns true on valid vat #{valid_vat}" do
       Valvat::Checksum.validate(valid_vat).should eql(true)
     end


### PR DESCRIPTION
Some notes:
I've checked in two commits on purpose. So far I've identified three types of validatable VAT IDs which use different checksum algorithms - legal entities, local natural persons, foreign natural persons.

Unfortunately local and foreign natural persons cannot be programatically distinguished. They both have 10 digits length and can only differ by their checksum digit. The solution I did is not very elegant, but I preferred it to making changes in the other code and possibly breaking something else. Please check the method check_digit_natural_person in lib/valvat/checksum/bg.rb as it can use some refactoring.

The test case's IDs are randomly generated using the algorithm, as according to Bulgarian law that data is treated as protected by privacy law. I've done testing on real IDs, to which I have lawful access, prior to switching them to randomly generated ones.
