### PR TITLE
Add syntax regular expression to support Croatian numbers

### DIFF
--- a/lib/valvat/syntax.rb
+++ b/lib/valvat/syntax.rb
@@ -17,6 +17,7 @@ class Valvat
         'FI' => /\AFI[0-9]{8}\Z/,                                           # Finland
         'FR' => /\AFR[A-Z0-9]{2}[0-9]{9}\Z/,                                # France
         'GB' => /\AGB([0-9]{9}|[0-9]{12}|(HA|GD)[0-9]{3})\Z/,               # United Kingdom
+        'HR' => /\AHR[0-9]{11}\Z/,                                          # Croatia
         'HU' => /\AHU[0-9]{8}\Z/,                                           # Hungary
         'IE' => /\AIE([0-9][A-Z][0-9]{5}|[0-9]{7})[A-Z]\Z/,                 # Ireland
         'IT' => /\AIT[0-9]{11}\Z/,                                          # Italy

--- a/lib/valvat/utils.rb
+++ b/lib/valvat/utils.rb
@@ -1,7 +1,7 @@
 class Valvat
   module Utils
 
-    EU_COUNTRIES = %w(AT BE BG CY CZ DE DK EE ES FI FR GB GR HU IE IT LT LU LV MT NL PL PT RO SE SI SK)
+    EU_COUNTRIES = %w(AT BE BG CY CZ DE DK EE ES FI FR GB GR HR HU IE IT LT LU LV MT NL PL PT RO SE SI SK)
     COUNTRY_PATTERN = /\A([A-Z]{2})(.+)\Z/
     NORMALIZE_PATTERN = /[-\.:_\s,;]+/
 

--- a/spec/valvat/syntax_spec.rb
+++ b/spec/valvat/syntax_spec.rb
@@ -108,6 +108,14 @@ describe Valvat::Syntax do
       subject.validate("HU6789459J").should eql(false)
     end
 
+    it "validates a HR vat number" do
+      subject.validate("HR12345678912").should eql(true)
+
+      subject.validate("HR6789459").should eql(false)
+      subject.validate("HR67894595L").should eql(false)
+      subject.validate("HR6789459J").should eql(false)
+    end
+
     it "validates a IE vat number" do
       subject.validate("IE1B12345J").should eql(true)
       subject.validate("IE1234567B").should eql(true)


### PR DESCRIPTION
Add support for Croatian vat id numbers because Croatia will join the European Union on the 1th of July.

The syntax of Croatian numbers is as follows: HR + 11 digits
