### PR TITLE
I18n support for country specific error messages extended

### DIFF
--- a/lib/valvat/locales/it.yml
+++ b/lib/valvat/locales/it.yml
@@ -1,0 +1,34 @@
+it:
+  errors:
+    messages:
+      invalid_vat: IVA non valido per %{country_adjective}
+  valvola:
+    country_adjectives:
+      eu: Europa
+      at: Austria
+      be: Belgio
+      bg: Bulgaria
+      cy: Cipro
+      cz: Repubblica Ceca
+      de: Germania
+      dk: Danimarca
+      ee: Estonia
+      es: Spagna
+      fi: Finlandia
+      fr: Francia
+      gb: Regno Unito
+      gr: Grecia
+      hu: Ungheria
+      ie: Irlanda
+      it: Italia
+      lt: Lituania
+      lu: Lussemburgo
+      lv: Lettonia
+      mt: Malta
+      nl: Paesi Bassi
+      pl: Polonia
+      pt: Portogallo
+      ro: Romania
+      se: Svezia
+      si: Slovenia
+      sk: Slovacchia

--- a/lib/valvat/locales/lv.yml
+++ b/lib/valvat/locales/lv.yml
@@ -1,0 +1,34 @@
+lv:
+  errors:
+    messages:
+      invalid_vat: nav derīgs %{country_adjective} PVN numurs
+  valvat:
+    country_adjectives:
+      eu: Eiropas
+      at: Austrijas
+      be: Beļģijas
+      bg: Bulgārijas
+      cy: Kipras
+      cz: Čehijas
+      de: Vācijas
+      dk: Dānijas
+      ee: Igaunijas
+      es: Spāņijas
+      fi: Somijas
+      fr: Francijas
+      gb: Lielbritānijas
+      gr: Grieķu
+      hu: Ungārijas
+      ie: Īrijas
+      it: Itālijas
+      lt: Lietuvas
+      lu: Luksemburgas
+      lv: Latvijas
+      mt: Maltas
+      nl: Holandiešu
+      pl: Polijas
+      pt: Portugāļu
+      ro: Rumānijas
+      se: Zviedrijas
+      si: Slovēnijas
+      sk: Slovāku

--- a/lib/valvat/locales/pl.yml
+++ b/lib/valvat/locales/pl.yml
@@ -1,0 +1,34 @@
+pl:
+  errors:
+    messages:
+      invalid_vat: nie jest prawidłowym %{country_adjective} numerem VAT
+  valvat:
+    country_adjectives:
+      eu: europejski
+      at: austriacki
+      be: belgijski
+      bg: bułgarski
+      cy: cypryjski
+      cz: czeski
+      de: niemiecki
+      dk: duński
+      ee: estoński
+      es: hiszpański
+      fi: fiński
+      fr: francuski
+      gb: angielski
+      gr: grecki
+      hu: węgierski
+      ie: irlandzki
+      it: włoski
+      lt: litewski
+      lu: luksemburski
+      lv: łotewski
+      mt: maltański
+      nl: holenderski
+      pl: polski
+      pt: portugalski
+      ro: rumuński
+      se: szwedzki
+      si: słoweński
+      sk: słowacki

--- a/lib/valvat/locales/pt.yml
+++ b/lib/valvat/locales/pt.yml
@@ -1,0 +1,34 @@
+pt:
+  errors:
+    messages:
+      invalid_vat: IVA inválido para %{country_adjective}
+  valvat:
+    country_adjectives:
+      eu: Europa
+      at: Áustria
+      be: Bélgica
+      bg: Bulgária
+      cy: Chipre
+      cz: República Checa
+      de: Alemanha
+      dk: Dinamarca
+      ee: Estónia
+      es: Espanha
+      fi: Finlândia
+      fr: França
+      gb: Reino Unido
+      gr: Grécia
+      hu: Hungria
+      ie: Irlanda
+      it: Itália
+      lt: Lituânia
+      lu: Luxemburgo
+      lv: Letónia
+      mt: Malta
+      nl: Holanda
+      pl: Polónia
+      pt: Portugal
+      ro: Roménia
+      se: Suécia
+      si: Eslovénia
+      sk: Eslováquia

--- a/lib/valvat/locales/ro.yml
+++ b/lib/valvat/locales/ro.yml
@@ -1,0 +1,34 @@
+ro:
+  errors:
+    messages:
+      invalid_vat: TVA invalid pentru %{country_adjective}
+  valvat:
+    country_adjectives:
+      eu: Europa
+      at: Austria
+      be: Belgia
+      bg: Bulgaria
+      cy: Cipru
+      cz: Cehia
+      de: Germania
+      dk: Danemarca
+      ee: Estonia
+      es: Spania
+      fi: Finlanda
+      fr: Franta
+      gb: Marea Britanie
+      gr: Grecia
+      hu: Ungaria
+      ie: Irlanda
+      it: Italia
+      lt: Lituania
+      lu: Luxembourg
+      lv: Latvia
+      mt: Malta
+      nl: Olanda
+      pl: Polonia
+      pt: Portugalia
+      ro: Romania
+      se: Suedia
+      si: Slovenia
+      sk: Slovacia


### PR DESCRIPTION
I18n support for country specific error messages extended to Polish, Romanian, Italian, Portuguese and Latvian
