### PR TITLE
Update to savon 2.3.0, remove namespace workaround

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 [full changelog](http://github.com/yolk/valvat/compare/v0.5.0...master)
 
+* Works now with current version of savon gem (2.3.0) (by [liggitt](https://github.com/liggitt))
+
 ### 0.5.0 / 2013-07-18
 
 [full changelog](http://github.com/yolk/valvat/compare/v0.4.7...v0.5.0)

--- a/gemfiles/activemodel-3-2
+++ b/gemfiles/activemodel-3-2
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "savon",       "2.2.0"
+gem "savon",       "2.3.0"
 gem "activemodel", "3.2.13"
 
 gem 'rspec', '>= 2.4.0'

--- a/gemfiles/activemodel-4
+++ b/gemfiles/activemodel-4
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "savon",       "2.2.0"
+gem "savon",       "2.3.0"
 gem "activemodel", "4.0"
 
 gem 'rspec', '>= 2.4.0'

--- a/gemfiles/standalone
+++ b/gemfiles/standalone
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "savon",       "2.2.0"
+gem "savon",       "2.3.0"
 
 gem 'rspec', '>= 2.4.0'
 gem 'fakeweb', '>= 1.3.0'

--- a/lib/valvat/lookup.rb
+++ b/lib/valvat/lookup.rb
@@ -31,14 +31,9 @@ class Valvat
         # Require Savon only if really needed!
         require 'savon' unless defined?(Savon)
 
-        # Quiet down HTTPI
-        HTTPI.log = false
-
         Savon::Client.new(
           wsdl: 'http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl',
-          namespace: 'urn:ec.europa.eu:taxud:vies:services:checkVat:types',
-          namespaces: {'xmlns:impl'=>'urn:ec.europa.eu:taxud:vies:services:checkVat:types'},
-          # Quiet down Savon
+          # Quiet down Savon and HTTPI
           log: false
         )
       end

--- a/valvat.gemspec
+++ b/valvat.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency             'savon',       '>=2.2.0'
+  s.add_dependency             'savon',       '>=2.3.0'
 
   s.add_development_dependency 'rspec',       '>= 2.4.0'
   s.add_development_dependency 'guard-rspec', '>=0.1.9'


### PR DESCRIPTION
Savon fixed namespace parsing in https://github.com/savonrb/savon/pull/476
We should stop hardcoding the namespace in valvat in case the VIES service changes their WSDL

Also, turning off HTTPI logging individually is no longer needed (c.f. http://savonrb.com/version2/globals.html)
