### PR TITLE
Correct regex for IE VAT numbers

### DIFF
--- a/lib/valvat/syntax.rb
+++ b/lib/valvat/syntax.rb
@@ -19,7 +19,7 @@ class Valvat
         'GB' => /\AGB([0-9]{9}|[0-9]{12}|(HA|GD)[0-9]{3})\Z/,               # United Kingdom
         'HR' => /\AHR[0-9]{11}\Z/,                                          # Croatia
         'HU' => /\AHU[0-9]{8}\Z/,                                           # Hungary
-        'IE' => /\AIE([0-9][A-Z][0-9]{5}|[0-9]{7})[A-Z]\Z/,                 # Ireland
+        'IE' => /\AIE([0-9][A-Z][0-9]{5}|[0-9]{7}[A-Z]?)[A-Z]\Z/,           # Ireland
         'IT' => /\AIT[0-9]{11}\Z/,                                          # Italy
         'LT' => /\ALT([0-9]{9}|[0-9]{12})\Z/,                               # Lithuania
         'LU' => /\ALU[0-9]{8}\Z/,                                           # Luxembourg

--- a/spec/valvat/syntax_spec.rb
+++ b/spec/valvat/syntax_spec.rb
@@ -119,10 +119,12 @@ describe Valvat::Syntax do
     it "validates a IE vat number" do
       subject.validate("IE1B12345J").should eql(true)
       subject.validate("IE1234567B").should eql(true)
+      subject.validate("IE1234567XX").should eql(true)
 
       subject.validate("IE1B123459").should eql(false)
       subject.validate("IE19123450").should eql(false)
       subject.validate("IEA9123450").should eql(false)
+      subject.validate("IE1B12345XX").should eql(false)
     end
 
     it "validates a IT vat number" do


### PR DESCRIPTION
According to http://www.hmrc.gov.uk/vat/managing/international/esl/country-codes.htm VAT numbers for Ireland have the following format (where "X" is [A-Z]):

1234567X
1X23456X
1234567XX
(8 or 9 characters)

The proposed change allows for an optional, penultimate alpha character.
