### PR TITLE
Fixed typo in de error message.

### DIFF
--- a/lib/valvat/locales/de.yml
+++ b/lib/valvat/locales/de.yml
@@ -1,7 +1,7 @@
 de:
   errors:
     messages:
-      invalid_vat: ist kein gültige %{country_adjective} UStId-Nr.
+      invalid_vat: ist keine gültige %{country_adjective} UStId-Nr.
   valvat:
     country_adjectives:
       eu: europäische


### PR DESCRIPTION
Fixed typo in the error message sentance to: Field ist keine gültige deutsche UStId-Nr.
