### PR TITLE
Do not recursively require things to prevent a segfault, do not use extensions

### DIFF
--- a/lib/valvat/checksum.rb
+++ b/lib/valvat/checksum.rb
@@ -1,5 +1,3 @@
-require 'valvat'
-
 class Valvat
   module Checksum
     ALGORITHMS = {}
@@ -78,4 +76,6 @@ class Valvat
   end
 end
 
-Dir.glob(File.dirname(__FILE__) + "/checksum/*.rb", &method(:require))
+Dir.glob(File.dirname(__FILE__) + "/checksum/*.rb").each do | rb_full_path |
+  require(rb_full_path.gsub(/\.rb$/, '')) # On Ruby 2.1.0 ActiveSupport goes mad if you pass it paths with .rb at the end
+end

--- a/lib/valvat/checksum/at.rb
+++ b/lib/valvat/checksum/at.rb
@@ -1,5 +1,3 @@
-require 'valvat/checksum'
-
 class Valvat
   module Checksum
     class AT < Base

--- a/lib/valvat/checksum/be.rb
+++ b/lib/valvat/checksum/be.rb
@@ -1,5 +1,3 @@
-require 'valvat/checksum'
-
 class Valvat
   module Checksum
     class BE < Base

--- a/lib/valvat/checksum/de.rb
+++ b/lib/valvat/checksum/de.rb
@@ -1,5 +1,3 @@
-require 'valvat/checksum'
-
 class Valvat
   module Checksum
     class DE < Base

--- a/lib/valvat/checksum/dk.rb
+++ b/lib/valvat/checksum/dk.rb
@@ -1,5 +1,3 @@
-require 'valvat/checksum'
-
 class Valvat
   module Checksum
     class DK < Base

--- a/lib/valvat/checksum/es.rb
+++ b/lib/valvat/checksum/es.rb
@@ -1,5 +1,3 @@
-require 'valvat/checksum'
-
 class Valvat
   module Checksum
     class ES < Base

--- a/lib/valvat/checksum/fi.rb
+++ b/lib/valvat/checksum/fi.rb
@@ -1,5 +1,3 @@
-require 'valvat/checksum'
-
 class Valvat
   module Checksum
     class FI < Base

--- a/lib/valvat/checksum/gr.rb
+++ b/lib/valvat/checksum/gr.rb
@@ -1,5 +1,3 @@
-require 'valvat/checksum'
-
 class Valvat
   module Checksum
     class GR < Base

--- a/lib/valvat/checksum/ie.rb
+++ b/lib/valvat/checksum/ie.rb
@@ -1,5 +1,3 @@
-require 'valvat/checksum'
-
 class Valvat
   module Checksum
     class IE < Base

--- a/lib/valvat/checksum/it.rb
+++ b/lib/valvat/checksum/it.rb
@@ -1,5 +1,3 @@
-require 'valvat/checksum'
-
 class Valvat
   module Checksum
     class IT < Base

--- a/lib/valvat/checksum/lu.rb
+++ b/lib/valvat/checksum/lu.rb
@@ -1,5 +1,3 @@
-require 'valvat/checksum'
-
 class Valvat
   module Checksum
     class LU < Base

--- a/lib/valvat/checksum/nl.rb
+++ b/lib/valvat/checksum/nl.rb
@@ -1,5 +1,3 @@
-require 'valvat/checksum'
-
 class Valvat
   module Checksum
     class NL < Base

--- a/lib/valvat/checksum/pl.rb
+++ b/lib/valvat/checksum/pl.rb
@@ -1,5 +1,3 @@
-require 'valvat/checksum'
-
 class Valvat
   module Checksum
     class PL < Base

--- a/lib/valvat/checksum/pt.rb
+++ b/lib/valvat/checksum/pt.rb
@@ -1,5 +1,3 @@
-require 'valvat/checksum'
-
 class Valvat
   module Checksum
     class PT < Base

--- a/lib/valvat/checksum/se.rb
+++ b/lib/valvat/checksum/se.rb
@@ -1,5 +1,3 @@
-require 'valvat/checksum'
-
 class Valvat
   module Checksum
     class SE < Base

--- a/lib/valvat/checksum/si.rb
+++ b/lib/valvat/checksum/si.rb
@@ -1,5 +1,3 @@
-require 'valvat/checksum'
-
 class Valvat
   module Checksum
     class SI < Base

--- a/lib/valvat/lookup.rb
+++ b/lib/valvat/lookup.rb
@@ -1,4 +1,3 @@
-require 'valvat'
 require 'savon'
 
 class Valvat

--- a/lib/valvat/syntax.rb
+++ b/lib/valvat/syntax.rb
@@ -1,5 +1,3 @@
-require 'valvat'
-
 class Valvat
   module Syntax
 


### PR DESCRIPTION
When loading the various checksum files, on Ubuntu with Ruby 2.1.0 the checksum calculators are globbed from checksum.rb. Each checksum calculator, in turn, requires checksum.rb - which causes an infinite require loop when used with ActiveSupport (that is not smart enough to figure out those requires are repeating). This is not reproducible in specs because standalone gem has the stock Ruby require in specs, not the pimped-up ActiveSupport version.

To avoid this problem, it is much better not to require things recursively because they get loaded during globbing.
We also got problems from requiring paths ending with .rb on our particular Ruby/ActiveSupport combination, and that also led to a segfault. When removing the extension ActiveSupport can manage those dependencies again and our application starts normally.
