### PR TITLE
Removes I18n deprecation warning from test runs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,8 @@ RSpec.configure do |config|
   config.backtrace_exclusion_patterns = [/rspec\/(core|expectations)/]
 end
 
+I18n.enforce_available_locales = false
+
 if defined?(ActiveModel)
   class ModelBase
     include ActiveModel::Serialization


### PR DESCRIPTION
Removes this deprecation warning from test run output.

```
[deprecated] I18n.enforce_available_locales will default to true in the future. If you really want to skip validation of your locale you can set I18n.enforce_available_locales = false to avoid this message.
```
