### PR TITLE
Add French checksum validations

### DIFF
--- a/lib/valvat/checksum/fr.rb
+++ b/lib/valvat/checksum/fr.rb
@@ -1,0 +1,14 @@
+class Valvat
+  module Checksum
+    class FR < Base
+      def check_digit
+        siren = str_wo_country[2..-1].to_i
+        (12 + (3 * siren) % 97) % 97
+      end
+      
+      def given_check_digit
+        str_wo_country[0..1].to_i
+      end
+    end
+  end
+end

--- a/spec/valvat/checksum/fr_spec.rb
+++ b/spec/valvat/checksum/fr_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Valvat::Checksum::FR do
+  %w(FR60528551658 FR43820567501).each do |valid_vat|
+    it "returns true on valid vat #{valid_vat}" do
+      expect(Valvat::Checksum.validate(valid_vat)).to eql(true)
+    end
+
+    invalid_vat = "#{valid_vat[0..-3]}#{valid_vat[-1]}#{valid_vat[-2]}"
+
+    it "returns false on invalid vat #{invalid_vat}" do
+      expect(Valvat::Checksum.validate(invalid_vat)).to eql(false)
+    end
+  end
+end

--- a/spec/valvat/checksum_spec.rb
+++ b/spec/valvat/checksum_spec.rb
@@ -9,7 +9,7 @@ end
 describe Valvat::Checksum do
   describe "#validate" do
     it "returns true on vat number with unknown checksum algorithm" do
-      expect(Valvat::Checksum.validate("FR99123543267")).to eql(true)
+      expect(Valvat::Checksum.validate("HR12345678901")).to eql(true)
     end
 
     it "returns false on corrupt number (e.g checks syntax)" do


### PR DESCRIPTION
I added a French checksum validation algorithm as follows:

FR VAT numbers format:
'FR'+ 2 digits (as validation key ) + 9 digits (as SIREN), the first and/or the second value can also be a character – e.g. FRXX999999999
The French key is calculated as follow : Key = [ 12 + 3 * ( SIREN modulo 97 ) ] modulo 97, for example  : Key = [ 12 + 3 * ( 404,833,048 modulo 97 ) ] modulo 97 = [12 + 3*56] modulo 97 = 180 modulo 97 = 83 so the tax number for 404,833,048 is FR 83,404,833,048 
source from : www.insee.fr

