### PR TITLE
Improve regexes and checksum coverage

### DIFF
--- a/lib/valvat/checksum/cy.rb
+++ b/lib/valvat/checksum/cy.rb
@@ -1,0 +1,19 @@
+class Valvat
+  module Checksum
+    class CY < Base
+      def check_digit
+        odd_position_digit_values = [1, 0, 5, 7, 9, 13, 15, 17, 19, 21]
+
+        sum = sum_figures_by do |digit, index|
+          (8 - index).odd? ? odd_position_digit_values[digit] : digit
+        end
+
+        ('a'..'z').to_a[sum % 26]
+      end
+
+      def given_check_digit
+        given_check_digit_str.downcase
+      end
+    end
+  end
+end

--- a/lib/valvat/checksum/ee.rb
+++ b/lib/valvat/checksum/ee.rb
@@ -1,0 +1,15 @@
+class Valvat
+  module Checksum
+    class EE < Base
+      def check_digit
+        multipliers = [7, 3, 1, 7, 3, 1, 7, 3]
+
+        sum = sum_figures_by do |digit, index|
+          digit * multipliers[index]
+        end
+
+        sum.ceil(-1) - sum
+      end
+    end
+  end
+end

--- a/lib/valvat/checksum/ee.rb
+++ b/lib/valvat/checksum/ee.rb
@@ -8,7 +8,7 @@ class Valvat
           digit * multipliers[index]
         end
 
-        sum.ceil(-1) - sum
+        ((sum / 10.0).ceil * 10).to_i - sum
       end
     end
   end

--- a/lib/valvat/checksum/hr.rb
+++ b/lib/valvat/checksum/hr.rb
@@ -1,0 +1,18 @@
+class Valvat
+  module Checksum
+    class HR < Base
+      def check_digit
+        product = 10
+        sum     = 0
+
+        figures.each do |figure|
+          sum = (figure + product) % 10
+          sum = 10 if sum.zero?
+          product = (2 * sum) % 11
+        end
+
+        (10 - (product - 1) % 10) % 10
+      end
+    end
+  end
+end

--- a/lib/valvat/checksum/hu.rb
+++ b/lib/valvat/checksum/hu.rb
@@ -1,0 +1,15 @@
+class Valvat
+  module Checksum
+    class HU < Base
+      def check_digit
+        multipliers = [3, 7, 9, 1, 3, 7, 9]
+
+        sum = sum_figures_by do |digit, index|
+          digit * multipliers[index]
+        end
+
+        (10 - sum % 10) % 10
+      end
+    end
+  end
+end

--- a/lib/valvat/checksum/lt.rb
+++ b/lib/valvat/checksum/lt.rb
@@ -1,0 +1,21 @@
+class Valvat
+  module Checksum
+    class LT < Base
+      def check_digit
+        base_checksum    = sum_with(0) % 11
+        shifted_checksum = sum_with(2) % 11
+
+        [base_checksum, shifted_checksum, 0].find { |checksum| checksum % 11 != 10 }
+      end
+
+      private
+
+      def sum_with(offset)
+        sum_figures_by do |digit, index|
+          multi_digit_multiplier = figures.size - index + offset
+          digit * (multi_digit_multiplier > 9 ? multi_digit_multiplier % 9 : multi_digit_multiplier)
+        end
+      end
+    end
+  end
+end

--- a/lib/valvat/checksum/mt.rb
+++ b/lib/valvat/checksum/mt.rb
@@ -1,0 +1,16 @@
+class Valvat
+  module Checksum
+    class MT < Base
+      check_digit_length 2
+
+      def check_digit
+        multipliers = [9, 8, 7, 6, 4, 3]
+
+        sum = sum_figures_by { |digit, index| digit * multipliers[index] }
+
+        supposed_checksum = 37 - (sum % 37)
+        supposed_checksum.zero? ? 37 : supposed_checksum
+      end
+    end
+  end
+end

--- a/lib/valvat/checksum/ro.rb
+++ b/lib/valvat/checksum/ro.rb
@@ -1,0 +1,16 @@
+class Valvat
+  module Checksum
+    class RO < Base
+      def check_digit
+        multipliers = [2, 3, 5, 7, 1, 2, 3, 5, 7]
+
+        sum = sum_figures_by { |digit, index| digit * multipliers[index] }
+        sum * 10 % 11 % 10
+      end
+
+      def figures_str
+        super.rjust(9, '0')
+      end
+    end
+  end
+end

--- a/lib/valvat/syntax.rb
+++ b/lib/valvat/syntax.rb
@@ -9,7 +9,7 @@ class Valvat
         'CZ' => /\ACZ[0-9]{8,10}\Z/,                                        # Czech Republic
         'DE' => /\ADE[0-9]{9}\Z/,                                           # Germany
         'DK' => /\ADK[0-9]{8}\Z/,                                           # Denmark
-        'EE' => /\AEE[0-9]{9}\Z/,                                           # Estonia
+        'EE' => /\AEE10[0-9]{7}\Z/,                                         # Estonia
         'GR' => /\AEL[0-9]{9}\Z/,                                           # Greece
         'ES' => /\AES([A-Z][0-9]{8}|[0-9]{8}[A-Z]|[A-Z][0-9]{7}[A-Z])\Z/,   # Spain
         'FI' => /\AFI[0-9]{8}\Z/,                                           # Finland

--- a/lib/valvat/syntax.rb
+++ b/lib/valvat/syntax.rb
@@ -19,7 +19,7 @@ class Valvat
         'HU' => /\AHU[0-9]{8}\Z/,                                           # Hungary
         'IE' => /\AIE([0-9][A-Z][0-9]{5}|[0-9]{7}[A-Z]?)[A-Z]\Z/,           # Ireland
         'IT' => /\AIT[0-9]{11}\Z/,                                          # Italy
-        'LT' => /\ALT([0-9]{9}|[0-9]{12})\Z/,                               # Lithuania
+        'LT' => /\ALT([0-9]{7}1[0-9]|[0-9]{10}1[0-9])\Z/,                   # Lithuania
         'LU' => /\ALU[0-9]{8}\Z/,                                           # Luxembourg
         'LV' => /\ALV[0-9]{11}\Z/,                                          # Latvia
         'MT' => /\AMT[0-9]{8}\Z/,                                           # Malta

--- a/lib/valvat/syntax.rb
+++ b/lib/valvat/syntax.rb
@@ -5,7 +5,7 @@ class Valvat
         'AT' => /\AATU[0-9]{8}\Z/,                                          # Austria
         'BE' => /\ABE0[0-9]{9}\Z/,                                          # Belgium
         'BG' => /\ABG[0-9]{9,10}\Z/,                                        # Bulgaria
-        'CY' => /\ACY[0-9]{8}[A-Z]\Z/,                                      # Cyprus
+        'CY' => /\ACY(?!12)[0-59][0-9]{7}[A-Z]\Z/,                          # Cyprus
         'CZ' => /\ACZ[0-9]{8,10}\Z/,                                        # Czech Republic
         'DE' => /\ADE[0-9]{9}\Z/,                                           # Germany
         'DK' => /\ADK[0-9]{8}\Z/,                                           # Denmark

--- a/spec/valvat/checksum/cy_spec.rb
+++ b/spec/valvat/checksum/cy_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Valvat::Checksum::CY do
+  %w(CY01234567U CY00532445O).each do |valid_vat|
+    it "returns true on valid vat #{valid_vat}" do
+      expect(Valvat::Checksum.validate(valid_vat)).to be true
+    end
+
+    invalid_vat = "#{valid_vat[0..-4]}#{valid_vat[-2]}#{valid_vat[-3]}"
+
+    it "returns false on invalid vat #{invalid_vat}" do
+      expect(Valvat::Checksum.validate(invalid_vat)).to be false
+    end
+  end
+end

--- a/spec/valvat/checksum/ee_spec.rb
+++ b/spec/valvat/checksum/ee_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe Valvat::Checksum::CY do
-  %w(CY01234567U CY00532445O).each do |valid_vat|
+describe Valvat::Checksum::EE do
+  %w(EE101234568 EE100207415).each do |valid_vat|
     it "returns true on valid vat #{valid_vat}" do
       expect(Valvat::Checksum.validate(valid_vat)).to be true
     end
 
-    invalid_vat = "#{valid_vat[0..-4]}#{valid_vat[-2]}#{valid_vat[-3]}#{valid_vat[-1]}"
+    invalid_vat = "#{valid_vat[0..-3]}#{valid_vat[-1]}#{valid_vat[-2]}"
 
     it "returns false on invalid vat #{invalid_vat}" do
       expect(Valvat::Checksum.validate(invalid_vat)).to be false

--- a/spec/valvat/checksum/hr_spec.rb
+++ b/spec/valvat/checksum/hr_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Valvat::Checksum::HR do
+  %w(HR06282943396 HR17099025134).each do |valid_vat|
+    it "returns true on valid vat #{valid_vat}" do
+      expect(Valvat::Checksum.validate(valid_vat)).to be true
+    end
+
+    invalid_vat = "#{valid_vat[0..-3]}#{valid_vat[-1]}#{valid_vat[-2]}"
+
+    it "returns false on invalid vat #{invalid_vat}" do
+      expect(Valvat::Checksum.validate(invalid_vat)).to be false
+    end
+  end
+end

--- a/spec/valvat/checksum/hu_spec.rb
+++ b/spec/valvat/checksum/hu_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Valvat::Checksum::HU do
+  %w(HU10672101 HU13460370 HU10747759).each do |valid_vat|
+    it "returns true on valid vat #{valid_vat}" do
+      expect(Valvat::Checksum.validate(valid_vat)).to be true
+    end
+
+    invalid_vat = "#{valid_vat[0..-3]}#{valid_vat[-1]}#{valid_vat[-2]}"
+
+    it "returns false on invalid vat #{invalid_vat}" do
+      expect(Valvat::Checksum.validate(invalid_vat)).to be false
+    end
+  end
+end

--- a/spec/valvat/checksum/lt_spec.rb
+++ b/spec/valvat/checksum/lt_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Valvat::Checksum::LT do
+  %w(LT213179412 LT290061371314).each do |valid_vat|
+    it "returns true on valid vat #{valid_vat}" do
+      expect(Valvat::Checksum.validate(valid_vat)).to be true
+    end
+
+    invalid_vat = "#{valid_vat[0..-3]}#{valid_vat[-1]}#{valid_vat[-2]}"
+
+    it "returns false on invalid vat #{invalid_vat}" do
+      expect(Valvat::Checksum.validate(invalid_vat)).to be false
+    end
+  end
+end

--- a/spec/valvat/checksum/mt_spec.rb
+++ b/spec/valvat/checksum/mt_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Valvat::Checksum::MT do
+  %w(MT11407334 MT10126313 MT11539237).each do |valid_vat|
+    it "returns true on valid vat #{valid_vat}" do
+      expect(Valvat::Checksum.validate(valid_vat)).to be true
+    end
+
+    invalid_vat = "#{valid_vat[0..-3]}#{valid_vat[-1]}#{valid_vat[-2]}"
+
+    it "returns false on invalid vat #{invalid_vat}" do
+      expect(Valvat::Checksum.validate(invalid_vat)).to be false
+    end
+  end
+end

--- a/spec/valvat/checksum/ro_spec.rb
+++ b/spec/valvat/checksum/ro_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Valvat::Checksum::RO do
+  %w(RO123456789 RO99908 RO19 RO124 RO13182060).each do |valid_vat|
+    it "returns true on valid vat #{valid_vat}" do
+      expect(Valvat::Checksum.validate(valid_vat)).to be true
+    end
+
+    invalid_vat = "#{valid_vat[0..-3]}#{valid_vat[-1]}#{valid_vat[-2]}"
+
+    it "returns false on invalid vat #{invalid_vat}" do
+      expect(Valvat::Checksum.validate(invalid_vat)).to be false
+    end
+  end
+end

--- a/spec/valvat/checksum_spec.rb
+++ b/spec/valvat/checksum_spec.rb
@@ -9,7 +9,7 @@ end
 describe Valvat::Checksum do
   describe "#validate" do
     it "returns true on vat number with unknown checksum algorithm" do
-      expect(Valvat::Checksum.validate("HR12345678901")).to eql(true)
+      expect(Valvat::Checksum.validate("CZ699001237")).to eql(true)
     end
 
     it "returns false on corrupt number (e.g checks syntax)" do

--- a/spec/valvat/syntax_spec.rb
+++ b/spec/valvat/syntax_spec.rb
@@ -66,10 +66,10 @@ describe Valvat::Syntax do
     end
 
     it "validates a EE vat number" do
-      expect(subject.validate("EE678678456")).to eql(true)
-      expect(subject.validate("EE6786784560")).to eql(false)
-      expect(subject.validate("EE67867845")).to eql(false)
-      expect(subject.validate("EE67867845K")).to eql(false)
+      expect(subject.validate("EE100207415")).to eql(true)
+      expect(subject.validate("EE1002074150")).to eql(false)
+      expect(subject.validate("EE10020741")).to eql(false)
+      expect(subject.validate("EE100207415K")).to eql(false)
     end
 
     it "validates a FI vat number" do

--- a/spec/valvat/syntax_spec.rb
+++ b/spec/valvat/syntax_spec.rb
@@ -145,15 +145,17 @@ describe Valvat::Syntax do
     end
 
     it "validates a LT vat number" do
-      expect(subject.validate("LT678678987")).to eql(true)
-      expect(subject.validate("LT678678987956")).to eql(true)
+      expect(subject.validate("LT213179412")).to eql(true)
+      expect(subject.validate("LT290061371314")).to eql(true)
 
-      expect(subject.validate("LT67867898")).to eql(false)
-      expect(subject.validate("LT6786789870")).to eql(false)
-      expect(subject.validate("LT678678987K")).to eql(false)
-      expect(subject.validate("LT67867898709")).to eql(false)
-      expect(subject.validate("LT6786789870C")).to eql(false)
-      expect(subject.validate("LT67867898795H")).to eql(false)
+      expect(subject.validate("LT21317942")).to eql(false)
+      expect(subject.validate("LT213179422")).to eql(false)
+      expect(subject.validate("LT2131794120")).to eql(false)
+      expect(subject.validate("LT213179412K")).to eql(false)
+      expect(subject.validate("LT29006137132")).to eql(false)
+      expect(subject.validate("LT290061371324")).to eql(false)
+      expect(subject.validate("LT29006137131C")).to eql(false)
+      expect(subject.validate("LT290061371314H")).to eql(false)
     end
 
     it "validates a LU vat number" do


### PR DESCRIPTION
* Some of the regexes were too permissive.
* Added checksum validation for a number of countries.

Sources:
[1](http://85.81.229.78/systems/DKVIES/-%20Arkiv/Algoritme%E6ndringer/VIES-VAT%20Validation%20Routines-v15.0.doc), [2](http://www.braemoor.co.uk/software/vat.shtml) (suggested [here](https://github.com/yolk/valvat/issues/41))

I skipped Switzerland as there is already [an existing PR](https://github.com/yolk/valvat/pull/45).

I tried to stick as much as possible to the existing style and testing practices.
