### PR TITLE
More tolerant normalize regexp to strip unicode spaces and more

### DIFF
--- a/lib/valvat/utils.rb
+++ b/lib/valvat/utils.rb
@@ -3,7 +3,7 @@ class Valvat
 
     EU_COUNTRIES = %w(AT BE BG CY CZ DE DK EE ES FI FR GB GR HR HU IE IT LT LU LV MT NL PL PT RO SE SI SK)
     COUNTRY_PATTERN = /\A([A-Z]{2})(.+)\Z/
-    NORMALIZE_PATTERN = /[-\.:_\s,;]+/
+    NORMALIZE_PATTERN = /[^A-Z0-9]+/
 
     def self.split(vat)
       COUNTRY_PATTERN =~ vat

--- a/lib/valvat/utils.rb
+++ b/lib/valvat/utils.rb
@@ -3,7 +3,7 @@ class Valvat
 
     EU_COUNTRIES = %w(AT BE BG CY CZ DE DK EE ES FI FR GB GR HR HU IE IT LT LU LV MT NL PL PT RO SE SI SK)
     COUNTRY_PATTERN = /\A([A-Z]{2})(.+)\Z/
-    NORMALIZE_PATTERN = /[^A-Z0-9]+/
+    NORMALIZE_PATTERN = /[[:space:][:punct:][:cntrl:]]+/
 
     def self.split(vat)
       COUNTRY_PATTERN =~ vat

--- a/spec/valvat/utils_spec.rb
+++ b/spec/valvat/utils_spec.rb
@@ -49,6 +49,7 @@ describe Valvat::Utils do
 
     it "removes special chars" do
       expect(Valvat::Utils.normalize("DE.345-889_00:3,;")).to eql("DE345889003")
+      expect(Valvat::Utils.normalize("→ DE·34588 9003 ☺")).to eql("DE345889003")
     end
   end
 

--- a/spec/valvat/utils_spec.rb
+++ b/spec/valvat/utils_spec.rb
@@ -49,7 +49,7 @@ describe Valvat::Utils do
 
     it "removes special chars" do
       expect(Valvat::Utils.normalize("DE.345-889_00:3,;")).to eql("DE345889003")
-      expect(Valvat::Utils.normalize("→ DE·34588 9003 ☺")).to eql("DE345889003")
+      expect(Valvat::Utils.normalize("→ DE·Ö34588 9003\0 ☺")).to eql("→DEÖ345889003☺")
     end
   end
 


### PR DESCRIPTION
Hi,

First of all thanks for this nice library :)

I noticed a strange issue recently with some VAT numbers with spaces being normalized and others not. Turns out it was because they were using some unicode spaces like the [punctuation space.](https://www.compart.com/en/unicode/U+2008)

I think we can easily improve handling of these by stripping any kind of unknown chars instead of just the one listed in the normalize regexp so I did this in this MR and added a spec for a VAT number with various unwanted chars, not just the classic ones.

Let me know what you think!