### PR TITLE
add RE country code to EU Countries

### DIFF
--- a/lib/valvat/utils.rb
+++ b/lib/valvat/utils.rb
@@ -1,7 +1,7 @@
 class Valvat
   module Utils
 
-    EU_COUNTRIES = %w(AT BE BG CY CZ DE DK EE ES FI FR GB GR HR HU IE IT LT LU LV MT NL PL PT RO SE SI SK)
+    EU_COUNTRIES = %w(AT BE BG CY CZ DE DK EE ES FI FR GB GR HR HU IE IT LT LU LV MT NL PL PT RE RO SE SI SK)
     COUNTRY_PATTERN = /\A([A-Z]{2})(.+)\Z/
     NORMALIZE_PATTERN = /[[:space:][:punct:][:cntrl:]]+/
 


### PR DESCRIPTION
Réunion is an outermost region of the European Union and, as an overseas department of France, part of the eurozone. It should be included in the EU Countries.