### PR TITLE
Fix checksum computation for Slovenian VAT ID.

### DIFF
--- a/lib/valvat/checksum/si.rb
+++ b/lib/valvat/checksum/si.rb
@@ -8,7 +8,7 @@ class Valvat
 
       def check_digit
         chk = sum_of_figues_for_pt_si
-        chk == 1 ? 0 : chk
+        chk == 10 ? 0 : chk
       end
     end
   end

--- a/spec/valvat/checksum/si_spec.rb
+++ b/spec/valvat/checksum/si_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 describe Valvat::Checksum::SI do
-  %w(SI59082437 SI51049406 SI86154575 SI47431857 SI22511822 SI22511880).each do |valid_vat|
+  %w(SI59082437 SI51049406 SI86154575 SI47431857 SI22511822 SI26833921).each do |valid_vat|
     it "returns true on valid vat #{valid_vat}" do
       expect(Valvat::Checksum.validate(valid_vat)).to eql(true)
     end
 
-    invalid_vat = "#{valid_vat[0..-5]}#{valid_vat[-1]}#{valid_vat[-4]}#{valid_vat[-3]}#{valid_vat[-2]}"
+    invalid_vat = "#{valid_vat[0..-2]}#{valid_vat[-1].to_i+1}"
 
     it "returns false on invalid vat #{invalid_vat}" do
       expect(Valvat::Checksum.validate(invalid_vat)).to eql(false)


### PR DESCRIPTION
Also updated tests with the valid SI VAT ID SI26833921 to illustrate the
bug. Had to remove the invalid SI22511880 from the list of valid VAT IDs
in the tests as it's in fact invalid. I've double-checked the validity of
the SI VAT IDs at:

http://ec.europa.eu/taxation_customs/vies/