### PR TITLE
Validate new dutch 2020 freelancer vat identification number

### DIFF
--- a/lib/valvat/checksum/nl.rb
+++ b/lib/valvat/checksum/nl.rb
@@ -1,6 +1,11 @@
 class Valvat
   module Checksum
     class NL < Base
+      def validate
+        vat.to_s.gsub(/[A-Z]/) { |let| (let.ord - 55).to_s }.to_i % 97 == 1 ||
+        super
+      end
+
       def check_digit
         sum_figures_by do |fig, i|
           fig*(i+2)

--- a/spec/valvat/checksum/nl_spec.rb
+++ b/spec/valvat/checksum/nl_spec.rb
@@ -7,7 +7,7 @@ describe Valvat::Checksum::NL do
     end
 
     invalid_vat = "#{valid_vat[0..-5]}#{valid_vat[-2]}#{valid_vat[-3]}#{valid_vat[-4]}#{valid_vat[-1]}#{valid_vat[-2]}#{valid_vat[-3]}"
-    
+
     it "returns false on invalid vat #{invalid_vat}" do
       expect(Valvat::Checksum.validate(invalid_vat)).to eql(false)
     end

--- a/spec/valvat/checksum/nl_spec.rb
+++ b/spec/valvat/checksum/nl_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 describe Valvat::Checksum::NL do
-  %w(NL123456782B12 NL802549391B01 NL808661863B01 NL820893559B01).each do |valid_vat|
+  %w(NL123456782B12 NL802549391B01 NL808661863B01 NL820893559B01 NL000099998B57 NL123456789B13).each do |valid_vat|
     it "returns true on valid vat #{valid_vat}" do
       expect(Valvat::Checksum.validate(valid_vat)).to eql(true)
     end
 
-    invalid_vat = "#{valid_vat[0..-5]}#{valid_vat[-2]}#{valid_vat[-3]}#{valid_vat[-4]}#{valid_vat[-1]}"
-
+    invalid_vat = "#{valid_vat[0..-5]}#{valid_vat[-2]}#{valid_vat[-3]}#{valid_vat[-4]}#{valid_vat[-1]}#{valid_vat[-2]}#{valid_vat[-3]}"
+    
     it "returns false on invalid vat #{invalid_vat}" do
       expect(Valvat::Checksum.validate(invalid_vat)).to eql(false)
     end


### PR DESCRIPTION
From 1-1-2020 there will be new vat_identification numbers in the Netherlands for freelancers. 
The old number had 'privacy' sensitive information, and because of that every freelancer in the Netherlands received a new vat identification number without privacy sensitive information which is valid from 1-1-2020.

The new number does not validate according to the current '11' check, but instead validates with a '97' check. This check is now added with two examples in the specs.

The check needs to substitute the letters with a number (A=10, B=11, C=13 etc) and then the `total % 97` has to equal 1 to be a valid vat identification number.

From 1-1-2020 and forward this new number will also validate with VIES.

For non freelancers the old 11-check number still exists, thus the validation needs to handle both these formats.

More information on the tax service in the netherlands (In dutch: https://www.belastingdienst.nl/wps/wcm/connect/nl/btw/content/wat-betekent-het-nieuwe-btw-id-voor-mij )