### PR TITLE
Follow redirects

### DIFF
--- a/lib/valvat/lookup.rb
+++ b/lib/valvat/lookup.rb
@@ -29,7 +29,7 @@ class Valvat
       end
 
       def client
-        @client ||= Savon::Client.new(wsdl: VIES_WSDL_URL, log: false)
+        @client ||= Savon::Client.new(wsdl: VIES_WSDL_URL, log: false, follow_redirects: true)
       end
     end
 


### PR DESCRIPTION
Seems like the service now redirects when requesting a VAT number lookup.

Fixes https://github.com/yolk/valvat/issues/73 