### PR TITLE
Use https instead of http for VIES_WSDL_URL

### DIFF
--- a/lib/valvat/lookup.rb
+++ b/lib/valvat/lookup.rb
@@ -2,7 +2,7 @@ require 'savon'
 
 class Valvat
   class Lookup
-    VIES_WSDL_URL = 'http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl'
+    VIES_WSDL_URL = 'https://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl'
     REMOVE_KEYS = [:valid, :@xmlns]
 
     attr_reader :vat, :options


### PR DESCRIPTION
Seems that `http` URL started redirecting to `https`

```
❯ curl -v http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl
*   Trying 2a01:7080:24:100::666:30...
* TCP_NODELAY set
*   Trying 147.67.210.30...
* TCP_NODELAY set
* Connected to ec.europa.eu (2a01:7080:24:100::666:30) port 80 (#0)
> GET /taxation_customs/vies/checkVatService.wsdl HTTP/1.1
> Host: ec.europa.eu
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 307 Temporary Redirect
< Location: https://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl
< Cache-Control: no-cache
< Pragma: no-cache
< Content-Type: text/html; charset=utf-8
< Proxy-Connection: close
< Connection: close
< Content-Length: 738
<
<HTML><HEAD>
<TITLE>Redirect</TITLE>
</HEAD>
<BODY>
<FONT face="Helvetica">
<big><strong></strong></big><BR>
</FONT>
<blockquote>
<TABLE border=0 cellPadding=1 width="80%">
<TR><TD>
<FONT face="Helvetica">
<big>Redirect (policy_request_redirect)</big>
<BR>
<BR>
</FONT>
</TD></TR>
<TR><TD>
<FONT face="Helvetica">
Click <a href="https:&#x2F;&#x2F;ec.europa.eu&#x2F;taxation_customs&#x2F;vies&#x2F;checkVatService.wsdl">here</a> if you are not automatically redirected.
</FONT>
</TD></TR>
<TR><TD>
<FONT face="Helvetica">

</FONT>
</TD></TR>
<TR><TD>
<FONT face="Helvetica" SIZE=2>
<BR>
For assistance, contact your network support team.
</FONT>
</TD></TR>
</TABLE>
</blockquote>
</FONT>
</BODY></HTML>
* Closing connection 0```