### PR TITLE
Test with Rails 5.2 instead of 5.0

### DIFF
--- a/gemfiles/activemodel-5
+++ b/gemfiles/activemodel-5
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 gem "savon",       ">=2.3.0"
-gem "activemodel", "~> 5.0.2"
+gem "activemodel", "~> 5.2.0"
 
 gem 'rspec', '~> 3.0'
 gem 'rack'


### PR DESCRIPTION
Follows the same schema as the other gemfiles which test the latest minor release, i.e.
https://github.com/yolk/valvat/blob/7313ee19fdb621472cab1b41c460e091175e2b21/gemfiles/activemodel-5#L4