### PR TITLE
fix The given SOAPAction checkVat does not match an operation.

### DIFF
--- a/lib/valvat/lookup/request.rb
+++ b/lib/valvat/lookup/request.rb
@@ -15,7 +15,7 @@ class Valvat
 
       def perform
         Response.new(
-          client.call(action, message: message, message_tag: message_tag)
+          client.call(action, message: message, message_tag: message_tag, soap_action: nil)
         )
       rescue Savon::SOAPFault => e
         Fault.new(e)


### PR DESCRIPTION
For some unknown reason this gem now throws this error: `The given SOAPAction checkVat does not match an operation.`

The reason for this is that savon inserts a SOAPaction header that brokes it. This workaround removes that header and the error is no longer risen. I didn't find any other workaround to remove this error. For more info look here:

Savon::SOAPRequest#configure_headers