### PR TITLE
Remove duplication on French error messages

### DIFF
--- a/lib/valvat/locales/fr.yml
+++ b/lib/valvat/locales/fr.yml
@@ -1,7 +1,7 @@
 fr:
   errors:
     messages:
-      invalid_vat: "Numéro de TVA %{country_adjective} invalide"
+      invalid_vat: "n’est pas un numéro de TVA %{country_adjective} valide"
       vies_down: "Impossible de valider votre numéro de TVA : le service de validation VIES est indisponible. Merci de réessayer ultérieurement."
   valvat:
     country_adjectives:


### PR DESCRIPTION
In the French locale the current error message is written as if the message was standalone, instead of following the field name, as is the default with ActiveRecord.

Currently, if the field is called "Numéro de TVA":

```rb
record.errors.full_messages
# => ["Numéro de TVA Numéro de TVA français invalide"]
```

With this change:
```rb
record.errors.full_messages
# => ["Numéro de TVA n’est pas un numéro de TVA valide"]
```