### PR TITLE
Update BE regex in syntax.rb

### DIFF
--- a/lib/valvat/syntax.rb
+++ b/lib/valvat/syntax.rb
@@ -4,7 +4,7 @@ class Valvat
   module Syntax
     VAT_PATTERNS = {
       'AT' => /\AATU[0-9]{8}\Z/,                                          # Austria
-      'BE' => /\ABE0[0-9]{9}\Z/,                                          # Belgium
+      'BE' => /\ABE[0-1][0-9]{9}\Z/,                                      # Belgium
       'BG' => /\ABG[0-9]{9,10}\Z/,                                        # Bulgaria
       'CY' => /\ACY(?!12)[0-59][0-9]{7}[A-Z]\Z/,                          # Cyprus
       'CZ' => /\ACZ[0-9]{8,10}\Z/,                                        # Czech Republic


### PR DESCRIPTION
Make BE regex future proof.

Based on following communication from Belgian government:

We currently use numbers starting with 0: “0.xxx.xxx.xxx” (0-series). However, the 0-series is not infinite. Once this series is exhausted, enterprise numbers will be assigned with the first number being 1: “1.xxx.xxx.xxx” (1-series).
Today there are still 183,600 enterprise numbers of the 0-series available. We estimate that at least 140,000 enterprise numbers beginning with “0” will be used up in the coming year. However, new projects (such as SABE – “loading of foreign entities”) may cause the 0-series to be used up faster than expected and thus more quickly numbers from the 1-series will be put into use.

We therefore ask you, by 01/01/2023 at the latest:
if necessary, to adapt your applications (which use the enterprise number) as soon as possible so that you can use the numbers of 1-series in the future;
to inform your customers.