### PR TITLE
Fix for Spain natural person VAT Validation

### DIFF
--- a/lib/valvat/checksum/es.rb
+++ b/lib/valvat/checksum/es.rb
@@ -4,7 +4,7 @@ class Valvat
   module Checksum
     class ES < Base
       NATURAL_PERSON_CHARS       = %w[T R W A G M Y F P D X B N J Z S Q V H L C K E].freeze
-      NATURAL_PERSON_EXP         = /\A(\d{8}[ABCDEFGHJKLMNPQRSTVWXYZ]|[KLMXYZ]\d{7}[ABCDEFGHJKLMNPQRSTVWXYZ])\Z/.freeze
+      NATURAL_PERSON_EXP         = /\A([KLMXYZ\d])/.freeze
       LEGAL_PERSON_CHARS = [false] + %w[A B C D E F G H I J]
       LEGAL_PERSON_EXP   = /\A[NPQRSW]\d{7}[ABCDEFGHIJ]\Z/.freeze
       NIE_DIGIT_BY_LETTER = %w[X Y Z].freeze

--- a/spec/valvat/checksum/es_spec.rb
+++ b/spec/valvat/checksum/es_spec.rb
@@ -15,4 +15,12 @@ describe Valvat::Checksum::ES do
       expect(Valvat::Checksum.validate(invalid_vat)).to be(false)
     end
   end
+
+  describe "if starts with [KLMXYZ\\d], is always a natural person" do
+    invalid_vat = "ESX65474207"
+    it "returns false on invalid VAT #{invalid_vat}" do
+      expect(Valvat::Checksum.validate(invalid_vat)).to be(false)
+    end
+  end
+
 end


### PR DESCRIPTION
Is some cases, Valvat was applying Legal Person rules to a Natural Person VAT, causing invalid NIF's to be validated (e.g: ESX65474207)

If the VAT starts with `/\A[KLMXYZ\d]/`, we should always validate as a natural person.

___ 

We also are missing a lot of more rules that the AEAT applies in his official validation library written in Java, I'm working on it on [es_vat_with_all_aeat_rules](https://github.com/KirtashW17/valvat/tree/es_vat_with_all_aeat_rules) but it will be a major change on Valvat::Checksum::ES.  I will open another PR once finished.

Rules: http://www.migoia.com/website/articulos/NIF.html
Official Library: https://ws024.juntadeandalucia.es/maven/repository/internal/com/aeat/valida/valnif/2.0.1/