### PR TITLE
Es VAT checksum validation with all AEAT rules

### DIFF
--- a/lib/valvat/checksum/es.rb
+++ b/lib/valvat/checksum/es.rb
@@ -4,32 +4,55 @@ class Valvat
   module Checksum
     class ES < Base
       NATURAL_PERSON_CHARS       = %w[T R W A G M Y F P D X B N J Z S Q V H L C K E].freeze
-      NATURAL_PERSON_EXP         = /\A([KLMXYZ\d])/.freeze
+      NATURAL_PERSON_EXP         = /\A[KLMXYZ\d]/.freeze
       LEGAL_PERSON_CHARS = [false] + %w[A B C D E F G H I J]
-      LEGAL_PERSON_EXP   = /\A[NPQRSW]\d{7}[ABCDEFGHIJ]\Z/.freeze
       NIE_DIGIT_BY_LETTER = %w[X Y Z].freeze
+      GIVEN_CD_IS_A_LETTER_EXP   = /[A-Z]\Z/.freeze
+      LEGAL_PERSON_EXP = /\A[ABCDEFGHJUVNPQRSW]/
+      CIF_MUST_BE_A_LETTER_EXP = /\A[NPQRSW]/
+      CIF_MUST_BE_A_NUMBER_EXP = /\A[HJUV]/
+      SPECIAL_NIF_EXP = /\A[KLM]/
 
-      def check_digit
-        natural_person? ? check_digit_natural_person : check_digit_legal_person
+      def validate
+        passes_special_validations? && possible_check_digits.include?(given_check_digit)
       end
 
-      def check_digit_natural_person
-        letter = vat.to_s_wo_country[0]
-        nie_digit = NIE_DIGIT_BY_LETTER.index(letter)
-        NATURAL_PERSON_CHARS["#{nie_digit}#{figures_str}".to_i.modulo(23)]
-      end
+      private
 
-      def check_digit_legal_person
-        chk = 10 - sum_of_figures_for_at_es_it_se(reverse_ints: true).modulo(10)
-        if legal_foreign_person?
-          LEGAL_PERSON_CHARS[chk]
-        else
-          (chk == 10 ? 0 : chk)
-        end
+      def passes_special_validations?
+        !(
+          # [KLM]: CD first two numerical digits must be between 01 and 56 (both inclusive)
+          vat.to_s_wo_country =~ SPECIAL_NIF_EXP &&
+          vat.to_s_wo_country[1..2].to_i > 56 or vat.to_s_wo_country[1..2].to_i < 01 ||
+          # Exceptions: X0000000T, 00000001R, 00000000T, 99999999R are invalid.
+          %w[X0000000T 00000001R 00000000T 99999999R].include?(vat.to_s_wo_country)
+        )
       end
 
       def given_check_digit
-        person? ? str_wo_country[-1] : super
+        given_cd_is_a_letter? ? str_wo_country[-1] : super
+      end
+
+      def possible_check_digits
+        natural_person? ? possible_cd_natural_person : possible_cds_legal_person
+      end
+
+      def possible_cd_natural_person
+        letter = vat.to_s_wo_country[0]
+        nie_digit = NIE_DIGIT_BY_LETTER.index(letter)
+        [NATURAL_PERSON_CHARS["#{nie_digit}#{figures_str}".to_i.modulo(23)]]
+      end
+
+      def possible_cds_legal_person
+        chk = 10 - sum_of_figures_for_at_es_it_se(reverse_ints: true).modulo(10)
+        possible_check_digits = []
+        if cd_can_be_a_letter?
+          possible_check_digits << LEGAL_PERSON_CHARS[chk]
+        end
+        if cd_can_be_a_num?
+          possible_check_digits << (chk == 10 ? 0 : chk)
+        end
+        possible_check_digits
       end
 
       def str_wo_country
@@ -46,7 +69,19 @@ class Valvat
       end
 
       def legal_foreign_person?
-        !!(vat.to_s_wo_country =~ LEGAL_PERSON_EXP)
+        !!(vat.to_s_wo_country =~ FOREIGN_LEGAL_PERSON_EXP)
+      end
+
+      def cd_can_be_a_letter?
+        !(vat.to_s_wo_country =~ CIF_MUST_BE_A_NUMBER_EXP)
+      end
+
+      def cd_can_be_a_num?
+        !(vat.to_s_wo_country =~ CIF_MUST_BE_A_LETTER_EXP)
+      end
+
+      def given_cd_is_a_letter?
+        !!(vat.to_s_wo_country =~ GIVEN_CD_IS_A_LETTER_EXP)
       end
     end
   end

--- a/spec/valvat/checksum/es_spec.rb
+++ b/spec/valvat/checksum/es_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Valvat::Checksum::ES do
   %w[ESA13585625 ESB83871236 ESE54507058 ES25139013J ESQ1518001A ESQ5018001G ESX4942978W ESX7676464F ESB10317980
-     ESY3860557K ESY2207765D].each do |valid_vat|
+     ESY3860557K ESY2207765D ES28350472M ES41961720Z ESM1171170X ESK0928769Y].each do |valid_vat|
     it "returns true on valid VAT #{valid_vat}" do
       expect(Valvat::Checksum.validate(valid_vat)).to be(true)
     end
@@ -22,4 +22,50 @@ describe Valvat::Checksum::ES do
       expect(Valvat::Checksum.validate(invalid_vat)).to be(false)
     end
   end
+
+  describe 'some CIF categories (NPQRSW) require control-digit to be a letter' do
+    invalid_vat = "ESP65474207"
+    valid_vat = "ESP6547420G"
+
+    it "returns false on invalid VAT #{invalid_vat}" do
+      expect(Valvat::Checksum.validate(invalid_vat)).to be(false)
+    end
+    it "returns true on valid VAT #{valid_vat}" do
+      expect(Valvat::Checksum.validate(valid_vat)).to be(true)
+    end
+  end
+
+  describe 'some CIF categories (CDFGJNUV) allow both a numeric check digit and a letter' do
+    %w[ESC65474207 ESC6547420G].each do |valid_vat|
+      it "returns true on valid VAT #{valid_vat}" do
+        expect(Valvat::Checksum.validate(valid_vat)).to be(true)
+      end
+    end
+  end
+
+  describe 'applies special rules to validation' do
+    describe 'special NIF categories (KLM) require CD to be a letter and first two digits to be between 01 and 56 (inclusive)' do
+      %w[ESK8201230M ESK0001230B].each do |invalid_vat|
+        it "returns false on invalid VAT #{invalid_vat}" do
+          expect(Valvat::Checksum.validate(invalid_vat)).to be(false)
+        end
+      end
+    end
+
+    describe 'Arbitrarily invalid VATs' do
+      %w[ESX0000000T ES00000001R ES00000000T ES99999999R].each do |invalid_vat|
+        it "returns false on invalid VAT #{invalid_vat}" do
+          expect(Valvat::Checksum.validate(invalid_vat)).to be(false)
+        end
+      end
+    end
+  end
+
+  describe 'if starts with [KLMXYZ\\d], is always a natural person' do
+    invalid_vat = 'ESX65474207'
+    it "returns false on invalid VAT #{invalid_vat}" do
+      expect(Valvat::Checksum.validate(invalid_vat)).to be(false)
+    end
+  end
+
 end


### PR DESCRIPTION
Applies more rules to SPAIN VAT Number validation:
- CIF: If first digit is in [ABCDEFG], check-digit can be both a letter or a number.
- CIF: If first digit is in [HJUV], check-digit MUST be a number.
- CIF: If first digit is in [NPQRSW], check-digit MUST be a letter.
- Adds rules for special NIF's [KLM]: First two digits must be between 01 and 56 (inclusive).
    
Based on official AEAT VAT validation Library written in Java:
- https://ws024.juntadeandalucia.es/maven/repository/internal/com/aeat/valida/valnif/2.0.1/
- http://www.migoia.com/website/articulos/NIF.html

I also did some JJUnit tests to confirm this behaviours of the official library:
 - [ValNifTest.zip](https://github.com/yolk/valvat/files/9594013/ValNifTest.zip)

