### PR TITLE
Improvements for Valvat::Checksum::FR

### DIFF
--- a/lib/valvat/checksum/fr.rb
+++ b/lib/valvat/checksum/fr.rb
@@ -3,6 +3,24 @@
 class Valvat
   module Checksum
     class FR < Base
+
+      # the valid characters for the first two digits (O and I are missing)
+      ALPHABET = '0123456789ABCDEFGHJKLMNPQRSTUVWXYZ'
+
+      def validate
+        if str_wo_country[0..1] =~ /^\d+$/
+          super
+        else
+          check =
+            if str_wo_country[0] =~ /\d/
+              ALPHABET.index(str_wo_country[0]) * 24 + ALPHABET.index(str_wo_country[1]) - 10
+            else
+              ALPHABET.index(str_wo_country[0]) * 34 + ALPHABET.index(str_wo_country[1]) - 100
+            end
+          (str_wo_country[2..].to_i + 1 + check / 11) % 11 == check % 11
+        end
+      end
+
       def check_digit
         siren = str_wo_country[2..-1].to_i
         (12 + (3 * siren) % 97) % 97

--- a/lib/valvat/syntax.rb
+++ b/lib/valvat/syntax.rb
@@ -14,7 +14,7 @@ class Valvat
       'GR' => /\AEL[0-9]{9}\Z/,                                           # Greece
       'ES' => /\AES([A-Z][0-9]{8}|[0-9]{8}[A-Z]|[A-Z][0-9]{7}[A-Z])\Z/,   # Spain
       'FI' => /\AFI[0-9]{8}\Z/,                                           # Finland
-      'FR' => /\AFR[A-Z0-9]{2}[0-9]{9}\Z/,                                # France
+      'FR' => /\AFR[A-HJ-NP-Z0-9]{2}[0-9]{9}\Z/,                          # France
       'GB' => /\A(GB|XI)([0-9]{9}|[0-9]{12}|(HA|GD)[0-9]{3})\Z/,          # United Kingdom
       'HR' => /\AHR[0-9]{11}\Z/,                                          # Croatia
       'HU' => /\AHU[0-9]{8}\Z/,                                           # Hungary

--- a/spec/valvat/checksum/fr_spec.rb
+++ b/spec/valvat/checksum/fr_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe Valvat::Checksum::FR do
-  %w[FR60528551658 FR43820567501].each do |valid_vat|
+  %w[FR60528551658 FR43820567501 FR0H384498879].each do |valid_vat|
     it "returns true on valid VAT #{valid_vat}" do
       expect(Valvat::Checksum.validate(valid_vat)).to be(true)
     end


### PR DESCRIPTION
When one of the two first characters is not numerical, we apply special validation rules.
Based on python-stdnum FR VAT validation: https://github.com/arthurdejong/python-stdnum