### PR TITLE
Fixes typo in Valvat::Checksum::ES

### DIFF
--- a/lib/valvat/checksum/es.rb
+++ b/lib/valvat/checksum/es.rb
@@ -23,9 +23,9 @@ class Valvat
         !(
           # [KLM]: CD first two numerical digits must be between 01 and 56 (both inclusive)
           (vat.to_s_wo_country =~ SPECIAL_NIF_EXP &&
-          vat.to_s_wo_country[1..2].to_i > 56) or vat.to_s_wo_country[1..2].to_i < 0o1 ||
-          # Exceptions: X0000000T, 00000001R, 00000000T, 99999999R are invalid.
-          %w[X0000000T 00000001R 00000000T 99999999R].include?(vat.to_s_wo_country)
+            (vat.to_s_wo_country[1..2].to_i > 56 || vat.to_s_wo_country[1..2].to_i < 1)) ||
+            # Exceptions: X0000000T, 00000001R, 00000000T & 99999999R are invalid.
+            %w[X0000000T 00000001R 00000000T 99999999R].include?(vat.to_s_wo_country)
         )
       end
 

--- a/spec/valvat/checksum/es_spec.rb
+++ b/spec/valvat/checksum/es_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Valvat::Checksum::ES do
   %w[ESA13585625 ESB83871236 ESE54507058 ES25139013J ESQ1518001A ESQ5018001G ESX4942978W ESX7676464F ESB10317980
-     ESY3860557K ESY2207765D ES28350472M ES41961720Z ESM1171170X ESK0928769Y].each do |valid_vat|
+     ESY3860557K ESY2207765D ES28350472M ES41961720Z ESM1171170X ESK0928769Y ES50095545G].each do |valid_vat|
     it "returns true on valid VAT #{valid_vat}" do
       expect(Valvat::Checksum.validate(valid_vat)).to be(true)
     end


### PR DESCRIPTION
Hi,

I noticed that I've made a typo in the commit [5e54550](https://github.com/yolk/valvat/pull/115/commits/5e54550a13faef417341ddc6dabecc3d1f5b5928)  (PR #115).  I'm very sorry.

A parenthesis was not placed correctly, causing the validation to fail for certain valid VATs (specifically those whose digits `[1..2]` were `00`.)