### PR TITLE
Fix incorrect variable usage in SOAP request body

### DIFF
--- a/lib/valvat/lookup/vies.rb
+++ b/lib/valvat/lookup/vies.rb
@@ -26,8 +26,8 @@ class Valvat
                 <urn:countryCode><%= @vat.vat_country_code %></urn:countryCode>
                 <urn:vatNumber><%= @vat.to_s_wo_country %></urn:vatNumber>
                 <% if @requester %>
-                <urn:requesterCountryCode><%= @vat.vat_country_code %></urn:requesterCountryCode>
-                <urn:requesterVatNumber><%= @vat.to_s_wo_country %></urn:requesterVatNumber>
+                <urn:requesterCountryCode><%= @requester.vat_country_code %></urn:requesterCountryCode>
+                <urn:requesterVatNumber><%= @requester.to_s_wo_country %></urn:requesterVatNumber>
                 <% end %>
             </urn:checkVat<%= 'Approx' if @requester %>>
           </soapenv:Body>


### PR DESCRIPTION
In the SOAP request body generation for the VIES VAT number validation, there was an incorrect usage of the `@vat` instance variable. 

This instance variable was used for the fields `requesterCountryCode` and `requesterVatNumber`. I assume that the actual instance variable should be `@requester`