### PR TITLE
Updated rexml dependency version to resolve the DoS vulnerability.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 
 [full changelog](http://github.com/yolk/valvat/compare/v1.4.1...master)
 
+* Resolved [rexml security vulnerability](https://github.com/ruby/rexml/security/advisories/GHSA-vg3r-rm7w-2xgh) by [Riana Ferreira](https://github.com/bad-vegan)
+
 ### 1.4.1 / 2024-01-08
 
 [full changelog](http://github.com/yolk/valvat/compare/v1.4.0...v1.4.1)

--- a/valvat.gemspec
+++ b/valvat.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  s.add_runtime_dependency('rexml', '>= 3.2', '< 4.0')
+  s.add_runtime_dependency('rexml', '>= 3.3.1', '< 4.0.0')
 end


### PR DESCRIPTION
## Context

The rexml dependency has a [DoS vulnerability](https://github.com/ruby/rexml/security/advisories/GHSA-vg3r-rm7w-2xgh)

> Name: rexml
> Version: 3.2.6
> CVE: CVE-2024-35176
> GHSA: GHSA-vg3r-rm7w-2xgh
> Criticality: Medium
> URL: https://github.com/ruby/rexml/security/advisories/GHSA-vg3r-rm7w-2xgh
> Title: REXML contains a denial of service vulnerability
> Solution: upgrade to '>= 3.2.7'

## What changed

- Update the runtime dependency version for rexml to use the latest version [3.3.1](https://github.com/ruby/rexml/releases/tag/v3.3.1).
- Noted the update in the change log.