### PR TITLE
Add translations back to the gem

### DIFF
--- a/valvat.gemspec
+++ b/valvat.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary                 = 'Validates european vat numbers. Standalone or as a ActiveModel validator.'
   s.description             = 'Validates european vat numbers. Standalone or as a ActiveModel validator.'
   s.required_ruby_version   = '>= 2.6.0'
-  s.files                   = Dir['lib/**/*.rb']
+  s.files                   = Dir['lib/**/*']
   s.cert_chain              = ['certs/mite.pem']
   s.signing_key             = File.expand_path('~/.ssh/gem-private_key.pem') if $PROGRAM_NAME.end_with?('gem')
   s.metadata = {


### PR DESCRIPTION
The change made in https://github.com/yolk/valvat/commit/0a97d777cbc8196b72ef1d7fe8d2d3484f7fec3d removed the translations from the gem. I am not sure this was intended? This change adds them back.