### PR TITLE
Updated rexml dependency version to resolve the DoS vulnerability.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 
 [full changelog](http://github.com/yolk/valvat/compare/v1.4.4...master)
 
+* Resolved the rexml security vulnerabilities that affected versions < 3.3.6 by [Riana Ferreira](https://github.com/bad-vegan)
+
 ### 1.4.4 / 2024-07-11
 
 [full changelog](http://github.com/yolk/valvat/compare/v1.4.3...v1.4.4)

--- a/valvat.gemspec
+++ b/valvat.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  s.add_dependency('rexml', '>= 3.2.7', '< 4.0.0')
+  s.add_dependency('rexml', '>= 3.3.6', '< 4.0.0')
 end


### PR DESCRIPTION
## Context

The current version of the rexml dependency has a number of DoS vulnerabilities that can be remediated by upgrading to the latest version ([3.3.6](https://github.com/ruby/rexml/releases/tag/v3.3.6)) of the gem.

<details>
  <summary><b><a href="https://github.com/ruby/rexml/security/advisories/GHSA-4xqq-m2hx-25v8">CVE-2024-39908 </a></b></summary>
  <blockquote>
    Name: rexml <br/>
    Version: 3.3.1 <br/>
    CVE: CVE-2024-39908 <br/>
    GHSA: GHSA-4xqq-m2hx-25v8 <br/>
    Criticality: Medium <br/>
    URL: https://github.com/ruby/rexml/security/advisories/GHSA-4xqq-m2hx-25v8 <br/>
    Title: DoS in REXML <br/>
    Solution: update to '>= 3.3.2' <br/>
  </blockquote>
</details>
<details>
  <summary><b><a href="https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41123">CVE-2024-41123</a></b></summary>
  <blockquote>
    Name: rexml<br/>
    Version: 3.3.1<br/>
    CVE: CVE-2024-41123<br/>
    GHSA: GHSA-r55c-59qm-vjw6<br/>
    Criticality: Medium<br/>
    URL: https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41123<br/>
    Title: DoS vulnerabilities in REXML<br/>
    Solution: update to '>= 3.3.3'<br/>
  </blockquote>
</details>
<details>
  <summary><b><a href="https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41946">CVE-2024-41946</a></b></summary>
  <blockquote>
    Name: rexml
    Version: 3.3.1<br/>
    CVE: CVE-2024-41946<br/>
    GHSA: GHSA-5866-49gr-22v4<br/>
    Criticality: Medium<br/>
    URL: https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41946<br/>
    Title: DoS vulnerabilities in REXML<br/>
    Solution: update to '>= 3.3.3'<br/>
  </blockquote>
</details>
<details>
  <summary><b><a href="https://github.com/ruby/rexml/security/advisories/GHSA-vmwr-mc7x-5vc3">CVE-2024-43398</a></b></summary>
  <blockquote>
    Name: rexml<br/>
    Version: 3.3.1<br/>
    CVE: CVE-2024-43398<br/>
    GHSA: GHSA-vmwr-mc7x-5vc3<br/>
    Criticality: Medium<br/>
    URL: https://github.com/ruby/rexml/security/advisories/GHSA-vmwr-mc7x-5vc3<br/>
    Title: REXML denial of service vulnerability<br/>
    Solution: update to '>= 3.3.6'<br/>
  </blockquote>
</details>

## What changed

- Update the rexml runtime dependency to use the latest version [3.3.6](https://github.com/ruby/rexml/releases/tag/v3.3.6).
- Noted the update in the change log.