### PR TITLE
Support HMRC API V2

### DIFF
--- a/lib/valvat/configuration.rb
+++ b/lib/valvat/configuration.rb
@@ -7,7 +7,7 @@ class Valvat
   # Configuration options should be set by passing a hash:
   #
   #   Valvat.configure(
-  #     uk: true
+  #     uk: { client_id: '<client_id>', client_secret: '<client_secret>' }
   #   )
   #
   def self.configure(options)
@@ -42,7 +42,20 @@ class Valvat
 
       # Use lookup via HMRC for VAT numbers from the UK
       # if set to false lookup will always return false for UK VAT numbers
-      uk: false
+      # HMRC options:
+      # - API credentials for OAuth 2.0 Authentication
+      # - Live mode for switching between Sandbox and Production API:
+      # * TRUE - Production API
+      # * FALSE - Sandbox API
+      # See more details https://developer.service.hmrc.gov.uk/api-documentation/docs/development-practices
+      uk: {
+        live: true,
+        client_id: nil,
+        client_secret: nil
+      }.freeze,
+
+      # Rate limit for Lookup and HMRC Authentication requests
+      rate_limit: 5
     }.freeze
 
     def self.initialize
@@ -53,8 +66,12 @@ class Valvat
       @data[key]
     end
 
+    def dig(*keys)
+      @data.dig(*keys)
+    end
+
     def configure(options)
-      @data = @data.merge(Utils.deep_symbolize_keys(options))
+      @data = @data.deep_merge(Utils.deep_symbolize_keys(options))
     end
 
     def initialize

--- a/lib/valvat/configuration.rb
+++ b/lib/valvat/configuration.rb
@@ -71,7 +71,7 @@ class Valvat
     end
 
     def configure(options)
-      @data = @data.deep_merge(Utils.deep_symbolize_keys(options))
+      @data = Utils.deep_merge(@data, Utils.deep_symbolize_keys(options))
     end
 
     def initialize

--- a/lib/valvat/error.rb
+++ b/lib/valvat/error.rb
@@ -31,4 +31,6 @@ class Valvat
   UnknownLookupError = Class.new(LookupError)
 
   HTTPError = Class.new(LookupError)
+
+  AuthorizationError = Class.new(LookupError)
 end

--- a/lib/valvat/hmrc/access_token.rb
+++ b/lib/valvat/hmrc/access_token.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+
+class Valvat
+  module HMRC
+    class AccessToken
+      Error = Class.new(StandardError)
+
+      PRODUCTION_ENDPOINT_URL = 'https://api.service.hmrc.gov.uk/oauth/token'
+      SANDBOX_ENDPOINT_URL = 'https://test-api.service.hmrc.gov.uk/oauth/token'
+      SCOPE = 'read:vat'
+      GRANT_TYPE = 'client_credentials'
+
+      def initialize(options = {})
+        @client_id = options.dig(:uk, :client_id).to_s
+        @client_secret = options.dig(:uk, :client_secret).to_s
+        @rate_limit = options[:rate_limit]
+        @endpoint_uri = URI(options.dig(:uk, :live) ? PRODUCTION_ENDPOINT_URL : SANDBOX_ENDPOINT_URL)
+      end
+
+      def self.fetch(options = {})
+        new(options).fetch
+      end
+
+      def fetch(uri = @endpoint_uri, request_count = 0)
+        raise_if_invalid!
+
+        request = build_request(uri)
+        response = build_https.request(request)
+        handle_response!(response, request_count)
+      rescue Errno::ECONNRESET, IOError
+        raise if request_count > @rate_limit
+
+        fetch(uri, request_count + 1)
+      end
+
+      private
+
+      def raise_if_invalid!
+        raise Error, 'Client ID is missing' if @client_id.empty?
+        raise Error, 'Client secret is missing' if @client_secret.empty?
+      end
+
+      def build_request(uri)
+        request = Net::HTTP::Post.new(uri)
+        request['Content-Type'] = 'application/x-www-form-urlencoded'
+        request.body = build_body
+        request
+      end
+
+      def build_body
+        URI.encode_www_form(
+          scope: SCOPE,
+          grant_type: GRANT_TYPE,
+          client_id: @client_id,
+          client_secret: @client_secret
+        )
+      end
+
+      def build_https
+        https = Net::HTTP.new(@endpoint_uri.host, @endpoint_uri.port)
+        https.use_ssl = true
+        https
+      end
+
+      def parse_response!(response)
+        JSON.parse(response.read_body)
+      end
+
+      def parse_response_location(response)
+        URI.parse(response['Location'])
+      end
+
+      # See https://developer.service.hmrc.gov.uk/api-documentation/docs/authorisation/application-restricted-endpoints
+      def handle_response!(response, request_count)
+        if response.is_a?(Net::HTTPRedirection) && request_count < @rate_limit
+          fetch(parse_response_location(response), request_count + 1)
+        elsif response.code == '200'
+          # {"access_token":"<access_token>","token_type":"bearer","expires_in":14400,"scope":"read:vat"}
+          parse_response!(response)['access_token']
+        else
+          raise Error, "Failed to fetch access token: #{handle_response_error(response, request_count)}"
+        end
+      end
+
+      def handle_response_error(response, request_count)
+        if response.code.match?(/4\d\d/)
+          # For 4xx codes: {"error":"invalid_client","error_description":"invalid client id or secret"}
+          parse_response!(response)['error_description']
+        elsif request_count >= @rate_limit
+          'rate limit exceeded'
+        else
+          response.read_body
+        end
+      end
+    end
+  end
+end

--- a/lib/valvat/lookup/base.rb
+++ b/lib/valvat/lookup/base.rb
@@ -10,6 +10,7 @@ class Valvat
         @vat = Valvat(vat)
         @options = Valvat::Options(options)
         @requester = @options[:requester] && Valvat(@options[:requester])
+        @rate_limit = @options[:rate_limit]
       end
 
       def perform
@@ -40,13 +41,13 @@ class Valvat
       def fetch(uri, limit = 0)
         response = send_request(uri)
 
-        if response == Net::HTTPRedirection && limit < 5
+        if response == Net::HTTPRedirection && limit < @rate_limit
           fetch(URI.parse(response['Location']), limit + 1)
         else
           response
         end
       rescue Errno::ECONNRESET, IOError
-        raise if limit > 5
+        raise if limit > @rate_limit
 
         fetch(uri, limit + 1)
       end

--- a/lib/valvat/options.rb
+++ b/lib/valvat/options.rb
@@ -23,6 +23,10 @@ class Valvat
     def [](key)
       @options.key?(key) ? @options[key] : Valvat.config[key]
     end
+
+    def dig(*keys)
+      @options.dig(*keys).nil? ? Valvat.config.dig(*keys) : @options.dig(*keys)
+    end
   end
 
   def self.Options(options)

--- a/lib/valvat/utils.rb
+++ b/lib/valvat/utils.rb
@@ -45,5 +45,10 @@ class Valvat
         val.is_a?(Hash) ? deep_symbolize_keys(val) : val
       end
     end
+
+    def self.deep_merge(original_hash, hash_to_merge)
+      merger = proc { |_key, v1, v2| v1.is_a?(Hash) && v2.is_a?(Hash) ? v1.merge(v2, &merger) : v2 }
+      original_hash.merge(hash_to_merge, &merger)
+    end
   end
 end

--- a/spec/valvat/hmrc/access_token_spec.rb
+++ b/spec/valvat/hmrc/access_token_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Valvat::HMRC::AccessToken do
+  subject(:fetch_access_token) { described_class.fetch(Valvat::Options(options)) }
+
+  let!(:options) { { uk: uk } }
+  let(:uk) { { live: false } }
+
+  shared_examples 'return access token' do
+    it 'return access token' do
+      expect(fetch_access_token).to eq('<access_token>')
+    end
+  end
+
+  shared_examples 'raises an error' do |error_message|
+    it 'raises an error' do
+      expect { fetch_access_token }.to raise_error(Valvat::HMRC::AccessToken::Error, error_message)
+    end
+  end
+
+  context 'with valid data' do
+    let(:uk) { super().merge(client_id: '<client_id>', client_secret: '<client_secret>') }
+    let(:response) do
+      {
+        status: 200,
+        body: {
+          access_token: '<access_token>',
+          token_type: 'bearer',
+          expires_in: 14_400,
+          scope: 'read:vat'
+        }.to_json
+      }
+    end
+
+    before do
+      stub_request(:post, 'https://test-api.service.hmrc.gov.uk/oauth/token')
+        .with(
+          body: {
+            scope: described_class::SCOPE,
+            grant_type: described_class::GRANT_TYPE,
+            client_id: uk[:client_id],
+            client_secret: uk[:client_secret]
+          }
+        )
+        .to_return(response)
+    end
+
+    include_examples 'return access token'
+
+    context 'when rate limit is exceeded' do
+      let(:response) do
+        {
+          status: 301,
+          headers: { location: 'https://test-api.service.hmrc.gov.uk/oauth/token' } # Redirection loop
+        }
+      end
+
+      include_examples 'raises an error', 'Failed to fetch access token: rate limit exceeded'
+    end
+  end
+
+  context 'with invalid data' do
+    context 'when Client ID is empty' do
+      let(:uk) { super().merge(client_id: nil, client_secret: '<client_secret>') }
+
+      include_examples 'raises an error', 'Client ID is missing'
+    end
+
+    context 'when Client ID is missing' do
+      let(:uk) { super().merge(client_secret: '<client_secret>') }
+
+      include_examples 'raises an error', 'Client ID is missing'
+    end
+
+    context 'when Client secret is empty' do
+      let(:uk) { super().merge(client_id: '<client_id>', client_secret: '') }
+
+      include_examples 'raises an error', 'Client secret is missing'
+    end
+
+    context 'when Client secret is missing' do
+      let(:uk) { super().merge(client_id: '<client_id>') }
+
+      include_examples 'raises an error', 'Client secret is missing'
+    end
+
+    context 'when HMRC return error' do
+      let(:uk) { super().merge(client_id: '<invlid_client_id>', client_secret: '<client_secret>') }
+      let(:response) do
+        {
+          status: 401,
+          body: {
+            error: 'invalid_client',
+            error_description: 'invalid client id or secret'
+          }.to_json
+        }
+      end
+
+      include_examples 'raises an error', 'Failed to fetch access token: invalid client id or secret'
+    end
+  end
+end

--- a/spec/valvat/lookup/hmrc_spec.rb
+++ b/spec/valvat/lookup/hmrc_spec.rb
@@ -3,56 +3,167 @@
 require 'spec_helper'
 
 describe Valvat::Lookup::HMRC do
+  subject(:lookup) { described_class.new("GB#{vat_number}", options).perform }
+
+  let(:options) { { uk: uk } }
+  let(:uk) { { live: false, client_id: '<client_id>', client_secret: '<client_secret>' } }
+  let(:vat_number) { '553557881' }
+  let(:authentication_response) do
+    {
+      status: 200,
+      body: {
+        access_token: '<access_token>',
+        token_type: 'bearer',
+        expires_in: 14_400,
+        scope: 'read:vat'
+      }.to_json
+    }
+  end
+  let(:lookup_response) do
+    {
+      status: 200,
+      body: {
+        target: {
+          address: {
+            line1: '131B Barton Hamlet',
+            postcode: 'SW97 5CK',
+            countryCode: 'GB'
+          },
+          vatNumber: vat_number,
+          name: 'Credite Sberger Donal Inc.'
+        },
+        processingDate: '2024-11-19T15:11:52+00:00'
+      }.to_json
+    }
+  end
+
+  shared_examples 'returns hash with valid: true and formatted data on success' do
+    it 'returns hash with valid: true and formatted data on success' do
+      expect(lookup).to include(
+        valid: true,
+        address: "131B Barton Hamlet\nSW97 5CK\nGB",
+        country_code: 'GB',
+        vat_number: vat_number,
+        name: 'Credite Sberger Donal Inc.',
+        request_date: kind_of(Time)
+      )
+    end
+  end
+
+  shared_examples 'returns hash with valid: false' do
+    it 'returns hash with valid: false' do
+      expect(lookup).to include(valid: false)
+    end
+  end
+
   before do
-    stub_const('Valvat::Lookup::HMRC::ENDPOINT_URL', 'https://test-api.service.hmrc.gov.uk/organisations/vat/check-vat-number/lookup')
+    Valvat.configure(uk: uk)
+
+    stub_request(:post, 'https://test-api.service.hmrc.gov.uk/oauth/token')
+      .with(
+        body: {
+          scope: Valvat::HMRC::AccessToken::SCOPE,
+          grant_type: Valvat::HMRC::AccessToken::GRANT_TYPE,
+          client_id: uk[:client_id],
+          client_secret: uk[:client_secret]
+        }
+      )
+      .to_return(authentication_response)
+
+    stub_request(:get, "https://test-api.service.hmrc.gov.uk/organisations/vat/check-vat-number/lookup/#{vat_number}")
+      .with(
+        headers: {
+          'Accept' => 'application/vnd.hmrc.2.0+json',
+          'Authorization' => 'Bearer <access_token>'
+        }
+      )
+      .to_return(lookup_response)
   end
 
   after do
-    Valvat.configure(uk: false)
+    Valvat.configure(uk: uk.merge(live: true))
   end
 
-  it 'returns hash with valid: true on success' do
-    response = described_class.new('GB553557881', { uk: true }).perform
+  context 'with valid data' do
+    let(:vat_number) { '553557881' }
 
-    expect(response).to match({
-                                valid: true,
-                                address: "131B Barton Hamlet\nSW97 5CK\nGB",
-                                country_code: 'GB',
-                                vat_number: '553557881',
-                                name: 'Credite Sberger Donal Inc.',
-                                request_date: kind_of(Time)
-                              })
+    include_examples 'returns hash with valid: true and formatted data on success'
+
+    context 'when :uk option is not set' do
+      let(:options) { {} }
+
+      include_examples 'returns hash with valid: true and formatted data on success'
+    end
+
+    context 'when options are not set' do
+      let(:options) { nil }
+
+      include_examples 'returns hash with valid: true and formatted data on success'
+
+      context 'when option uk: false set globally' do
+        before { Valvat.configure(uk: false) }
+
+        include_examples 'returns hash with valid: false'
+      end
+
+      context 'when option uk: nil set globally' do
+        before { Valvat.configure(uk: nil) }
+
+        include_examples 'returns hash with valid: false'
+      end
+    end
+
+    context 'when overwrite global :uk setting' do
+      let(:options) { { uk: false } }
+
+      before { Valvat.configure(uk: uk) }
+
+      include_examples 'returns hash with valid: false'
+    end
   end
 
-  it 'returns hash with valid: false on invalid input' do
-    response = described_class.new('GB123456789', { uk: true }).perform
-    expect(response).to match({ valid: false })
-  end
+  context 'with invalid data' do
+    shared_examples 'returns error' do
+      it 'returns error' do
+        expect { lookup }.not_to raise_error
+        expect(lookup[:error]).to be_a(Valvat::HMRC::AccessToken::Error)
+      end
+    end
 
-  it 'returns hash with valid: false on valid input with :uk option not set' do
-    response = described_class.new('GB553557881', {}).perform
-    expect(response).to match({ valid: false })
-  end
+    context 'when VAT invalid' do
+      let(:vat_number) { '123456789' }
+      let(:lookup_response) do
+        {
+          status: 404,
+          body: {
+            code: 'NOT_FOUND',
+            message: 'targetVrn does not match a registered company'
+          }.to_json
+        }
+      end
 
-  it 'returns valid: false when uk option is set to false' do
-    response = described_class.new('GB553557881', { uk: false }).perform
-    expect(response).to match({ valid: false })
-  end
+      include_examples 'returns hash with valid: false'
+    end
 
-  it 'returns valid: false when uk option is not set' do
-    response = described_class.new('GB553557881').perform
-    expect(response).to match({ valid: false })
-  end
+    context 'when missing Authentication credentials' do
+      let(:uk) { super().merge(client_id: nil, client_secret: nil) }
 
-  it 'respects global :uk setting' do
-    Valvat.configure(uk: true)
-    response = described_class.new('GB553557881').perform
-    expect(response).to include({ valid: true })
-  end
+      include_examples 'returns error'
+    end
 
-  it 'overwrite global :uk setting' do
-    Valvat.configure(uk: true)
-    response = described_class.new('GB553557881', uk: false).perform
-    expect(response).to include({ valid: false })
+    context 'when Authentication failed' do
+      let(:uk) { super().merge(client_id: '<invlid_client_id>') }
+      let(:authentication_response) do
+        {
+          status: 401,
+          body: {
+            error: 'invalid_client',
+            error_description: 'invalid client id or secret'
+          }.to_json
+        }
+      end
+
+      include_examples 'returns error'
+    end
   end
 end

--- a/spec/valvat/options_spec.rb
+++ b/spec/valvat/options_spec.rb
@@ -5,11 +5,17 @@ require 'spec_helper'
 describe Valvat::Options do
   describe '#[]' do
     it 'returns global config by default' do
-      expect(described_class.new({})[:uk]).to be(false)
+      expect(described_class.new({})[:uk]).to include(
+        {
+          live: true,
+          client_id: '<client_id>',
+          client_secret: '<client_secret>'
+        }
+      )
     end
 
     it 'returns option if set' do
-      expect(described_class.new({ uk: true })[:uk]).to be(true)
+      expect(described_class.new({ uk: false })[:uk]).to be(false)
     end
 
     context 'when options contains deprecated key' do

--- a/spec/valvat/utils_spec.rb
+++ b/spec/valvat/utils_spec.rb
@@ -122,4 +122,25 @@ describe Valvat::Utils do
       expect(described_class.deep_symbolize_keys({ 'a' => 1, :b => { 'c' => 3 } })).to eql({ a: 1, b: { c: 3 } })
     end
   end
+
+  describe '#deep_merge' do
+    let(:original_hash) { { a: 1, b: { c: 3 }, e: { w: 9 } } }
+    let(:hash_to_merge) { { b: { d: 4 }, e: { w: 10 }, y: 11 } }
+
+    it 'deep merge the nested hashes' do
+      expect(described_class.deep_merge(original_hash, hash_to_merge)).to eql(
+        {
+          a: 1,
+          b: {
+            c: 3,
+            d: 4
+          },
+          e: {
+            w: 10
+          },
+          y: 11
+        }
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Version 2 is the recommended version of this API. Version 1 will be removed in January 2025.
https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/vat-registered-companies-api/2.0 

Resolves issue - https://github.com/yolk/valvat/issues/137