### PR TITLE
Updated rexml dependency version to resolve security vulnerabilities.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 
 [full changelog](http://github.com/yolk/valvat/compare/v2.0.1...master)
 
+* Resolved the rexml security vulnerabilities that affected versions < 3.4.2  by [Riana Ferreira](https://github.com/bad-vegan)
+
 ### 2.0.1 / 2024-19-06
 
 [full changelog](http://github.com/yolk/valvat/compare/v.2.0.0...v2.0.1)

--- a/valvat.gemspec
+++ b/valvat.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  s.add_dependency('rexml', '>= 3.3.6', '< 4.0.0')
+  s.add_dependency('rexml', '>= 3.4.2', '< 4.0.0')
 end


### PR DESCRIPTION
Bumps the rexml runtime dependency version in valvat.gemspec from `>= 3.3.6` to `>= 3.4.2`. This remediates two REXML denial-of-service vulnerabilities.

### Context

**Vulnerabilities resolved**

[CVE-2024-49761](https://github.com/ruby/rexml/security/advisories/GHSA-2rxp-v6pw-ch6m) — REXML ReDoS

- Advisory: GHSA-2rxp-v6pw-ch6m
- Severity: Low (GitHub Security Advisory)
- Affected: rexml < 3.3.9
- Patched in: 3.3.9
- Summary: REXML's parser is susceptible to a Regular Expression Denial of Service attack when processing XML containing numerous digits between &# and x…; in hexadecimal numeric character references. Only impacts consumers running Ruby 3.1; Ruby 3.2+ is unaffected by the regex engine change that triggers the catastrophic backtracking.

[CVE-2025-58767](https://github.com/ruby/rexml/security/advisories/GHSA-c2f4-jgmc-q2r5) — REXML DoS on malformed XML

- Advisory: GHSA-c2f4-jgmc-q2r5
- Severity: Low
- Affected: rexml 3.3.3 – 3.4.1
- Patched in: 3.4.2
- Summary: REXML is susceptible to a denial-of-service condition when processing XML documents containing multiple XML declaration statements. Crafted input with repeated declarations causes the parser to consume excessive CPU/memory.

### What changed

- Update the rexml runtime dependency to use the latest version `>= 3.4.2` (upper bound `< 4.0.0` unchanged).
- Version update noted in the change log.